### PR TITLE
fix(upstream): Cherry-pick redb bug workaround

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -837,6 +837,10 @@ impl<'index> Updater<'index> {
     Index::increment_statistic(&wtx, Statistic::Commits, 1)?;
     wtx.commit()?;
 
+    // Commit twice since due to a bug redb will only reuse pages freed in the
+    // transaction before last.
+    self.index.begin_write()?.commit()?;
+
     Reorg::update_savepoints(self.index, self.height)?;
 
     Ok(())


### PR DESCRIPTION
Cherry-pick commit in https://github.com/ordinals/ord/pull/3856 which claims to reduce the size of the index by 70Gb in mainnet.